### PR TITLE
Add combo for right setting switch for v2

### DIFF
--- a/config/dya_dash.keymap
+++ b/config/dya_dash.keymap
@@ -110,6 +110,19 @@
             bindings = <&macro_param_1to1 &tog_off MACRO_PLACEHOLDER &macro_param_1to1 &mo MACRO_PLACEHOLDER>;
         };
     };
+    combos {
+        compatible = "zmk,combos";
+        setting_left {
+            timeout-ms = <10>;
+            key-positions = <47 50>;
+            bindings = <&kp C_VOL_DN>;
+        };
+        setting_right {
+            timeout-ms = <10>;
+            key-positions = <47 49>;
+            bindings = <&kp C_VOL_UP>;
+        };
+    };
 
     keymap {
         compatible = "zmk,keymap";


### PR DESCRIPTION
Two setting switches are added in right side for V2.
These pin assignments are actually shared with arrow keys. Clicking setting button works as clicking two arrow keys.
ZMK's combo feature can be used to detect these setting button.